### PR TITLE
feat(backend): add support for pyproject.toml files

### DIFF
--- a/.changeset/wise-buses-dance.md
+++ b/.changeset/wise-buses-dance.md
@@ -1,0 +1,5 @@
+---
+'@anakz/backstage-plugin-library-check-backend': minor
+---
+
+Add support for pyproject.toml files

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This plugin helps you explore project dependency libraries by offering insights 
 | ----------------------------- | -------------- | ----------------------------------------------------- | ------ |
 | package.json                  | JavaScript, TS | [npm](https://www.npmjs.com/)                         | ✅     |
 | requirements.txt              | Python         | [PyPI](https://pypi.org/)                             | ✅     |
+| pyproject.toml                | Python         | [PyPI](https://pypi.org/)                             | ✅     |
 | *.csproj                      | C#             | [Nuget](https://nuget.org/)                           | ✅     |
 | composer.json                 | PHP            | [Packagist](https://packagist.org/)                   | ✅     |            
 | pom.xml, build.gradle         | Java           | [Maven](https://maven.apache.org/)                    | 👩🏻‍💻     |

--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -8,10 +8,11 @@
 | ----------------------------- | -------------- | ----------------------------------------------------- | ------ |
 | package.json                  | JavaScript, TS | [npm](https://www.npmjs.com/)                         | ✅     |
 | requirements.txt              | Python         | [PyPI](https://pypi.org/)                             | ✅     |
+| pyproject.toml                | Python         | [PyPI](https://pypi.org/)                             | ✅     |
 | *.csproj                      | C#             | [Nuget](https://nuget.org/)                           | ✅     |
 | composer.json                 | PHP            | [Packagist](https://packagist.org/)                   | ✅     |            
 | pom.xml, build.gradle         | Java           | [Maven](https://maven.apache.org/)                    | 👩🏻‍💻     |
-| pyproject.toml                | Kotlin         | [Maven](https://maven.apache.org/)                    | 👩🏻‍💻     |
+| pom.xml, build.gradle.kts     | Kotlin         | [Maven](https://maven.apache.org/)                    | 👩🏻‍💻     |
 | go.mod                        | Go             | [pkg.go.dev](https://pkg.go.dev/)                     | ❌     |
 | CMakeLists.txt, conanfile.txt | C++            | [Conan](https://conan.io/)                            | ❌     |
 | pubspec.yaml                  | Dart           | [pub.dev](https://pub.dev/)                           | ❌     |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,7 +8,7 @@
 ### Descriptor files support:
 
 Initial support for: 
-`package.json`, `composer.json`, `requirements.txt`, `.csproj` files;
+`package.json`, `composer.json`, `requirements.txt`, `.csproj`, `pyproject.toml` files;
 
 Registries used:
 - Pypi

--- a/plugins/library-check-backend/package.json
+++ b/plugins/library-check-backend/package.json
@@ -65,6 +65,7 @@
     "p-limit": "^3.0.2",
     "pip-requirements-js": "^0.2.1",
     "semver": "^7.6.0",
+    "toml": "^3.0.0",
     "uuid": "^9.0.1",
     "winston": "^3.2.1",
     "xml2js": "^0.6.2",

--- a/plugins/library-check-backend/src/handlers/DescriptorFileHandler.ts
+++ b/plugins/library-check-backend/src/handlers/DescriptorFileHandler.ts
@@ -5,6 +5,7 @@ import { CsProjHandler } from './CsProjHandler';
 import { FileType, FileHandler, Libraries } from '../types';
 import { BuildGradleHandler } from './BuildGradleHandler';
 import { PomXmlHandler } from './PomXmlHandler';
+import { PyProjectTomlHandler } from './PyProjectTomlHandler';
 
 export class DescriptorFileHandler {
   private handlers: Record<FileType, FileHandler>;
@@ -17,6 +18,7 @@ export class DescriptorFileHandler {
       [FileType.CsProj]: new CsProjHandler(),
       [FileType.BuildGradle]: new BuildGradleHandler(),
       [FileType.PomXml]: new PomXmlHandler(),
+      [FileType.PyProjectToml]: new PyProjectTomlHandler(),
     };
   }
 

--- a/plugins/library-check-backend/src/handlers/How to add new handlers.md
+++ b/plugins/library-check-backend/src/handlers/How to add new handlers.md
@@ -37,7 +37,7 @@ export class YourFileTypeHandler implements FileHandler {
 
 ```
 
-### 3. Inject the handler on `handlers/DescriptiorFileHandler` class
+### 3. Inject the handler on `handlers/DescriptorFileHandler` class
 
 Connect the handler into the reader management logic;
 

--- a/plugins/library-check-backend/src/handlers/PyProjectTomlHandler.ts
+++ b/plugins/library-check-backend/src/handlers/PyProjectTomlHandler.ts
@@ -1,0 +1,59 @@
+import { FileHandler, Libraries } from '../types';
+import { validateSemverNotation } from '../utils/semver';
+import * as toml from 'toml';
+
+export class PyProjectTomlHandler implements FileHandler {
+  read(fileContent: string): Libraries {
+    if (!fileContent.trim()) {
+      return {};
+    }
+
+    const libraries: Libraries = {};
+
+    try {
+      const parsed = toml.parse(fileContent);
+
+      // Process main dependencies under [tool.poetry.dependencies]
+      const mainDependencies = parsed.tool?.poetry?.dependencies;
+      this.addDependencies(mainDependencies, 'core', libraries);
+
+      // Process old-style dev dependencies under [tool.poetry.dev-dependencies]
+      const devDependenciesOldStyle = parsed.tool?.poetry?.['dev-dependencies'];
+      this.addDependencies(devDependenciesOldStyle, 'dev', libraries);
+
+      // Process other dependency groups under [tool.poetry.group.<group_name>.dependencies]
+      const groups = parsed.tool?.poetry?.group;
+      if (groups && typeof groups === 'object') {
+        for (const [groupName, groupValue] of Object.entries(groups)) {
+          const groupDependencies = groupValue?.dependencies;
+          if (groupDependencies) {
+            this.addDependencies(groupDependencies, groupName, libraries);
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error parsing pyproject.toml content:', error);
+    }
+
+    return libraries;
+  }
+
+  // Function to process dependency information
+  private addDependencies(dependencies: any, type: string, libraries: Libraries) {
+    if (dependencies && typeof dependencies === 'object') {
+      for (const [packageName, packageVersion] of Object.entries(dependencies)) {
+        const formattedPackageName = `${type}:${packageName.replace(/\s/g, '')}`;
+
+        // Skip dependencies without a valid version, including wildcard version
+        if (typeof packageVersion === 'string' && packageVersion !== '*') {
+          const validatedVersion = validateSemverNotation(packageVersion);
+          if (validatedVersion !== undefined) {
+            libraries[formattedPackageName] = validatedVersion;
+          }
+        } else {
+          console.warn(`Ignoring package without specific version for "${packageName}":`, packageVersion);
+        }
+      }
+    }
+  }
+}

--- a/plugins/library-check-backend/src/handlers/index.ts
+++ b/plugins/library-check-backend/src/handlers/index.ts
@@ -3,3 +3,4 @@ export * from './DescriptorFileHandler';
 export * from './RequirementsTxtHandler';
 export * from './PackageJsonHandler';
 export * from './CsProjHandler';
+export * from './PyProjectTomlHandler';

--- a/plugins/library-check-backend/src/mappers/RegistryMapper.ts
+++ b/plugins/library-check-backend/src/mappers/RegistryMapper.ts
@@ -48,4 +48,5 @@ export const FileToLanguageMap: RegistryLanguageMap = {
   requirementstxt: 'python',
   pomxml: 'java',
   buildgradle: 'java',
+  pyprojecttoml: 'python',
 };

--- a/plugins/library-check-backend/src/processors/LibraryCheckProcessor.ts
+++ b/plugins/library-check-backend/src/processors/LibraryCheckProcessor.ts
@@ -88,6 +88,7 @@ export class LibraryCheckProcessor implements CatalogProcessor {
       '**/requirements.txt',
       '**/pom.xml',
       '**/build.gradle',
+      '**/pyproject.toml'
     ];
 
     // Search for files and read them

--- a/plugins/library-check-backend/src/tests/PyProjectTomlHandler.test.ts
+++ b/plugins/library-check-backend/src/tests/PyProjectTomlHandler.test.ts
@@ -1,0 +1,97 @@
+import { PyProjectTomlHandler } from '../handlers/PyProjectTomlHandler';
+
+describe('PyProjectTomlHandler', () => {
+  let pyProjectTomlHandler: PyProjectTomlHandler;
+
+  beforeEach(() => {
+    pyProjectTomlHandler = new PyProjectTomlHandler();
+  });
+
+  describe('read', () => {
+    it('should return an empty object if file content is empty', () => {
+      const fileContent = '';
+
+      const result = pyProjectTomlHandler.read(fileContent);
+
+      expect(result).toEqual({});
+    });
+
+    it('should parse file content and return libraries', () => {
+      const fileContent = `
+        [tool.poetry.dependencies]
+        package1 = "1.0"
+        package2 = "2.0"
+      `;
+
+      const result = pyProjectTomlHandler.read(fileContent);
+
+      expect(result).toEqual({
+        'core:package1': '1.0.0',
+        'core:package2': '2.0.0',
+      });
+    });
+
+    it('should ignore dependencies with wildcard versions', () => {
+      const fileContent = `
+        [tool.poetry.dependencies]
+        package1 = "*"
+        package2 = ">=2.0"
+      `;
+
+      const result = pyProjectTomlHandler.read(fileContent);
+
+      expect(result).toEqual({
+        'core:package2': '2.0.0',
+      });
+    });
+
+    it('should ignore lines that do not match the package format', () => {
+      const fileContent = `
+        [tool.poetry.dependencies]
+        package1 = "1.0"
+        # not_a_package_version_line
+        package2 = "2.0"
+      `;
+
+      const result = pyProjectTomlHandler.read(fileContent);
+
+      expect(result).toEqual({
+        'core:package1': '1.0.0',
+        'core:package2': '2.0.0',
+      });
+    });
+
+    it('should process dependencies under dependency groups', () => {
+      const fileContent = `
+        [tool.poetry.dependencies]
+        package1 = "1.0"
+        
+        [tool.poetry.group.dev.dependencies]
+        package2 = "2.0"
+      `;
+
+      const result = pyProjectTomlHandler.read(fileContent);
+
+      expect(result).toEqual({
+        'core:package1': '1.0.0',
+        'dev:package2': '2.0.0',
+      });
+    });
+
+    it('should log an error if parsing fails', () => {
+      const fileContent = 'invalid-toml-content'; // Invalid TOML content
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const result = pyProjectTomlHandler.read(fileContent);
+
+      expect(result).toEqual({});
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Error parsing pyproject.toml content:',
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/plugins/library-check-backend/src/types/index.ts
+++ b/plugins/library-check-backend/src/types/index.ts
@@ -75,6 +75,7 @@ export enum FileType {
   CsProj = 'csproj',
   PomXml = 'pomxml',
   BuildGradle = 'buildgradle',
+  PyProjectToml = 'pyprojecttoml',
 }
 
 export type Registry = {


### PR DESCRIPTION
### 📝 Description

This PR adds support for the pyproject.toml files used by [Poetry](https://python-poetry.org/) in Python, using the existing PyPi registry implementation for searching libraries and packages metadata.

### ⛳️ Current behavior

Does not support pyproject.toml files.

### 🚀 New behavior

pyproject.toml files are now discovered by the processor.

### 💣 Is this a breaking change (Yes/No):

No.

### 📝 Additional Information

### Checklist

- [X] Have you written tests for your changes?
- [X] Have you successfully ran tests with your changes locally?
- [X] Have you lint your code locally prior to submission?
- [X] Have you updated the plugin documentation with the changes?
