### PR TITLE
Add new backend support

### DIFF
--- a/plugins/library-check-backend/package.json
+++ b/plugins/library-check-backend/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.21.2",
-    "@backstage/backend-plugin-api": "^0.6.12",
+    "@backstage/backend-plugin-api": "^1.0.2",
     "@backstage/backend-tasks": "^0.5.17",
     "@backstage/backend-test-utils": "^0.3.3",
     "@backstage/catalog-model": "^1.4.4",

--- a/plugins/library-check-backend/src/processors/LibraryCheckProcessor.ts
+++ b/plugins/library-check-backend/src/processors/LibraryCheckProcessor.ts
@@ -1,4 +1,3 @@
-import { UrlReader } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
@@ -14,12 +13,12 @@ import { Library, TLanguages } from '../types';
 import * as T from '../types';
 import { LibraryCheckService } from '../service/LibraryCheckService';
 import { FileToLanguageMap, RegistryConfig } from '../mappers/RegistryMapper';
-import { DiscoveryService } from '@backstage/backend-plugin-api';
+import { DiscoveryService, UrlReaderService } from '@backstage/backend-plugin-api';
 
 export class LibraryCheckProcessor implements CatalogProcessor {
   private readonly integrations: ScmIntegrationRegistry;
   private readonly logger: Logger;
-  private readonly reader: UrlReader;
+  private readonly reader: UrlReaderService;
   private readonly descriptorHandler: DescriptorFileHandler;
   private readonly libraryCheckService: LibraryCheckService;
   private readonly discoveryService: DiscoveryService;
@@ -29,7 +28,7 @@ export class LibraryCheckProcessor implements CatalogProcessor {
     options: {
       logger: Logger;
       discoveryService: DiscoveryService;
-      reader: UrlReader;
+      reader: UrlReaderService;
     },
   ) {
     const integrations = ScmIntegrations.fromConfig(config);
@@ -43,7 +42,7 @@ export class LibraryCheckProcessor implements CatalogProcessor {
   constructor(options: {
     integrations: ScmIntegrationRegistry;
     logger: Logger;
-    reader: UrlReader;
+    reader: UrlReaderService;
     discoveryService: DiscoveryService;
   }) {
     this.discoveryService = options.discoveryService;
@@ -148,7 +147,9 @@ export class LibraryCheckProcessor implements CatalogProcessor {
           const { files } = await this.reader.search(url);
 
           if (files.length !== 0) {
+
             const processedFiles = await Promise.all(
+              //@ts-ignore
               files.map(async file => {
                 try {
                   const bufferContent = await file.content();

--- a/plugins/library-check-backend/src/processors/LibraryCheckUpdaterProcessor.ts
+++ b/plugins/library-check-backend/src/processors/LibraryCheckUpdaterProcessor.ts
@@ -1,4 +1,3 @@
-import { UrlReader } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
@@ -9,7 +8,7 @@ import { CatalogProcessor } from '@backstage/plugin-catalog-node';
 import { Logger } from 'winston';
 import * as T from '../types';
 import { LibraryCheckService } from '../service/LibraryCheckService';
-import { DiscoveryService } from '@backstage/backend-plugin-api';
+import {DiscoveryService, UrlReaderService} from '@backstage/backend-plugin-api';
 import { semverImpact, versionToObj } from '../utils/semver';
 import { LibraryUpdateRecord } from '../types';
 
@@ -22,7 +21,7 @@ export class LibraryCheckUpdaterProcessor implements CatalogProcessor {
     config: Config,
     options: {
       logger: Logger;
-      reader: UrlReader;
+      reader: UrlReaderService;
       discoveryService: DiscoveryService;
     },
   ) {
@@ -37,7 +36,7 @@ export class LibraryCheckUpdaterProcessor implements CatalogProcessor {
   constructor(options: {
     integrations: ScmIntegrationRegistry;
     logger: Logger;
-    reader: UrlReader;
+    reader: UrlReaderService;
     discoveryService: DiscoveryService;
   }) {
     this.discoveryService = options.discoveryService;


### PR DESCRIPTION
### 📝 Description

As discussed in #12, following the documentation does not lead to a working instance of this plugin, when you use the latest version of Backstage. I've created this PR as a draft to hopefully start collaboration on working on a solution for this. I will document below a small list of steps I've done to get Backstage to load the plugin.

1. Place the `plugins/library-check-backend` directory into your Backstage's `plugins/library-check-backend`
2. Place the following in your Backstage's `packages/backend/src/index.ts`
``` TypeScript
import {catalogProcessingExtensionPoint} from "@backstage/plugin-catalog-node/alpha";
import {loggerToWinstonLogger} from '@backstage/backend-common';
import {LibraryCheckProcessor, LibraryCheckUpdaterProcessor} from "../../../plugins/library-check-backend";

```


``` TypeScript
const libraryCheckModule = createBackendModule({
    pluginId: 'catalog',
    moduleId: 'library-check',
    register(env) {
        env.registerInit({
            deps: {
                catalog: catalogProcessingExtensionPoint,
                logger: coreServices.logger,
                scheduler: coreServices.scheduler,
                reader: coreServices.urlReader,
                discovery: coreServices.discovery,
                config: coreServices.rootConfig,
            },
            async init({ catalog, logger, scheduler, reader, discovery, config}) {

                const defaultSchedule = {
                    initialDelay: { seconds: 15 },
                    frequency: { minutes: 10 },
                    timeout: { minutes: 15 },
                };
                scheduler.createScheduledTaskRunner(defaultSchedule);

                const winstonLogger = loggerToWinstonLogger(logger);
                
                catalog.addProcessor(
                  LibraryCheckProcessor.fromConfig(
                    config,
                    {
                        reader: reader,
                        discoveryService: discovery,
                        logger: winstonLogger
                    }
                  )
                );
                catalog.addProcessor(
                  LibraryCheckUpdaterProcessor.fromConfig(
                    config,
                    {
                        reader: reader,
                        discoveryService: discovery,
                        logger: winstonLogger
                    }
                  )
                );
            },
        });
    },
});
```

``` TypeScript
backend.add(libraryCheckModule);
```


** THIS IS NOT A FULLY WORKING IMPLEMENTATION AT THIS POINT **
When I run backstage, and the "import" of all the library files starts, everything seems to fail.
A small excerpt of the logs that indicate failure:
```
backstage-application  | {"level":"info","message":"LibraryCheckProcessor: Saved entity metadata libraries on database","plugin":"catalog","service":"***"}
backstage-application  | {"level":"info","message":"[10/Dec/2024:06:38:56 +0000] \"POST /api/library-check/libraries HTTP/1.1\" 404 - \"-\" \"axios/1.7.8\"","service":"rootHttpRouter","type":"incomingRequest"}                                                                                                                               
backstage-application  | {"level":"info","message":"LibraryCheckProcessor: Descriptor files found at https://github.com/webgrip/github-webhook-observer/tree/main/**/requirements.txt","plugin":"catalog","service":"***"}                                                                                                                      
backstage-application  | {"level":"info","message":"LibraryCheckProcessor: Descriptor files found at https://github.com/webgrip/github-webhook-observer/tree/main/**/package.json","plugin":"catalog","service":"***"}                                                                                                                          
backstage-application  | {"level":"info","message":"LibraryCheckProcessor: Saved entity metadata libraries on database","plugin":"catalog","service":"***"}
backstage-application  | LibraryCheckService: Error trying to save libraries on database                                                                                
backstage-application  | {"level":"info","message":"[10/Dec/2024:06:38:56 +0000] \"POST /api/library-check/libraries/search HTTP/1.1\" 404 - \"-\" \"axios/1.7.8\"","service":"rootHttpRouter","type":"incomingRequest"}
backstage-application  | {"level":"info","message":"LibraryCheckProcessor: Saved entity metadata libraries on database","plugin":"catalog","service":"***"}
backstage-application  | {"level":"info","message":"LibraryCheckProcessor: Saved entity metadata libraries on database","plugin":"catalog","service":"***"}             
backstage-application  | {"level":"info","message":"LibraryCheckProcessor: Descriptor files found at https://github.com/webgrip/***-application/tree/main/**/package.json","plugin":"catalog","service":"***"}                                                                                                                                  
backstage-application  | LibraryCheckService: Error trying to search for libraries on database
backstage-application  | {"level":"info","message":"[10/Dec/2024:06:38:56 +0000] \"POST /api/library-check/libraries HTTP/1.1\" 404 - \"-\" \"axios/1.7.8\"","service":"rootHttpRouter","type":"incomingRequest"}                                                                                                                               
backstage-application  | {"level":"info","message":"[10/Dec/2024:06:38:56 +0000] \"POST /api/library-check/libraries-updates HTTP/1.1\" 404 - \"-\" \"axios/1.7.8\"","service":"rootHttpRouter","type":"incomingRequest"}                                                                                                                       
backstage-application  | {"level":"info","message":"[10/Dec/2024:06:38:56 +0000] \"POST /api/library-check/libraries HTTP/1.1\" 404 - \"-\" \"axios/1.7.8\"","service":"rootHttpRouter","type":"incomingRequest"}
backstage-application  | LibraryCheckService: Error trying to save libraries on database
backstage-application  | LibraryCheckService: Error trying to update libraries occurrences records on entities_libraries table AxiosError: Request failed with status code 404 
``` 

### ⛳️ Current behavior

Supports old backend

### 🚀 New behavior

Supports new backend

### 💣 Is this a breaking change (Yes/No):

Not sure yet, probably yes.

### 📝 Additional Information

I would like some help on this. I'm unfamiliar with the changes that one needs to make to migrate a backstage plugin to the new backend. It's been a slow process of trial and error so far. I'd like to leverage other people's expertise on the matter and hopefully start of a discussion on how this should be done.

### Checklist

- [ ] Have you written tests for your changes?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you lint your code locally prior to submission?
- [ ] Have you updated the plugin documentation with the changes?
